### PR TITLE
Adds support to laravel 6.0 and 7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,12 @@
     "keywords": ["bakle", "translator", "laravel", "google", "google translator"],
     "type": "library",
     "require": {
-        "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.3"
+        "php": ">=7.1",
+        "guzzlehttp/guzzle": "^6.3",
+        "laravel/framework": "^5.8.0|^6.0|^7.0"
     },
     "require-dev": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "guzzlehttp/guzzle": "^6.3"
     },
     "license": "MIT",

--- a/src/Clients/ClientTranslator.php
+++ b/src/Clients/ClientTranslator.php
@@ -3,6 +3,7 @@
 namespace Bakle\Translator\Clients;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
 
 class ClientTranslator
 {
@@ -124,7 +125,7 @@ class ClientTranslator
         $translated = json_decode($this->response->getBody()->getContents());
 
         if (!empty($translated) && !is_null($translated)) {
-            return array_first($translated->data->translations)->translatedText;
+            return Arr::first($translated->data->translations)->translatedText;
         }
     }
 

--- a/src/TranslatableFile.php
+++ b/src/TranslatableFile.php
@@ -2,6 +2,7 @@
 
 namespace Bakle\Translator;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -70,7 +71,7 @@ class TranslatableFile
      */
     public function unlockSpecialWords(): string
     {
-        return vsprintf(str_replace($this->lockerSymbols, '%s', $this->clientTranslator->getTranslatedText()), array_first($this->matches));
+        return vsprintf(str_replace($this->lockerSymbols, '%s', $this->clientTranslator->getTranslatedText()), Arr::first($this->matches));
     }
 
     /**

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4,6 +4,7 @@ namespace Bakle\Translator;
 
 use Bakle\Translator\TranslatableFile;
 use Bakle\Translator\Clients\ClientTranslator;
+use Illuminate\Support\Arr;
 
 class Translator
 {
@@ -14,7 +15,7 @@ class Translator
     /**
      * Relative file name from lang folder
      *
-     * @var string
+     * @var \Symfony\Component\Finder\SplFileInfo
      */
     private $file;
 
@@ -43,7 +44,7 @@ class Translator
 
     private $message;
 
-    public function __construct($file, $sourceLang, $targetLang)
+    public function __construct(\Symfony\Component\Finder\SplFileInfo $file, $sourceLang, $targetLang)
     {
         $this->sourceLang = $sourceLang;
         $this->targetLang = $targetLang;
@@ -62,7 +63,7 @@ class Translator
 
         $this->client->setTargetLang($this->targetLang);
         $fileToTranslate = include $this->file;
-        
+
         $progressBar = $consoleOutput->createProgressBar(count($fileToTranslate, COUNT_RECURSIVE));
         $progressBar->start();
 


### PR DESCRIPTION
- Replaces `array_first()` to `Arr::first()`

- Adds minimum php version as 7.1, seems like you are using return `void` types which are only available in php7.1

- Adds `illuminate/framework` as dependency, you may not use this package without laravel